### PR TITLE
dynamically changing action mask

### DIFF
--- a/muax/test.py
+++ b/muax/test.py
@@ -23,6 +23,10 @@ def test(model, env, key, num_simulations, num_test_episodes=10, random_seed=Non
     -------
     average_test_reward: float. The average total reward for `num_test_episodes` tests.
     """
+    try:
+        mask = env.get_invalid_actions_mask
+    except AttributeError:
+        mask = lambda: None
     total_rewards = np.zeros(num_test_episodes)
     for episode in range(num_test_episodes):
         obs, info = env.reset(seed=random_seed)
@@ -35,7 +39,8 @@ def test(model, env, key, num_simulations, num_test_episodes=10, random_seed=Non
                           with_value=False, 
                           obs_from_batch=False,
                           num_simulations=num_simulations,
-                          temperature=0.) # Use deterministic actions during testing
+                          temperature=0., # Use deterministic actions during testing
+                          invalid_actions=mask())
             obs_next, r, done, truncated, info = env.step(a)
             episode_reward += r
             if done or truncated:

--- a/muax/train.py
+++ b/muax/train.py
@@ -121,6 +121,11 @@ def fit(model,
       test_env = gym.make(env_id, render_mode='rgb_array')
     else:
       raise ValueError("You must provide `test_env` when using a custom `env`.")
+    
+  try:
+      mask = env.get_invalid_actions_mask
+  except AttributeError:
+      mask = lambda: None
 
   if name is None:
     name = env_id if env_id is not None else 'tmp'
@@ -157,7 +162,8 @@ def fit(model,
                            with_value=True, 
                            obs_from_batch=False,
                            num_simulations=num_simulations,
-                           temperature=temperature)
+                           temperature=temperature,
+                           invalid_actions=mask())
       obs_next, r, done, truncated, info = env.step(a)
 #       if truncated:
 #         r = 1 / (1 - tracer.gamma)
@@ -187,7 +193,8 @@ def fit(model,
                            with_value=True, 
                            obs_from_batch=False,
                            num_simulations=num_simulations,
-                           temperature=temperature)
+                           temperature=temperature,
+                           invalid_actions=mask())
       obs_next, r, done, truncated, info = env.step(a)
 #       if truncated:
 #         r = 1 / (1 - tracer.gamma)


### PR DESCRIPTION
# INCOMPLETE
Possible solution, not very elegant. https://github.com/bwfbowen/muax/issues/4
Lacks saving the mask in the buffer for sampling.
If author of an environment wants it, he implements the class method `get_invalid_actions_mask`.
Maybe abuse `info` for it?